### PR TITLE
Setup of Acceptance testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ pkg/
 .bundler
 .bundle
 Gemfile.lock
-spec/fixtures/modules/*

--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,10 @@ def location_for(place, fake_version = nil)
   end
 end
 
-group :development, :unit_tests do
+group :development, :test do
   gem 'rake',                    :require => false
-  gem 'rspec-core', '3.1.7',     :require => false
-  gem 'rspec-puppet', '~> 2.1',  :require => false
+  gem 'rspec-core',              :require => false
+  gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'puppet-lint',             :require => false
   gem 'simplecov',               :require => false
@@ -23,18 +23,6 @@ end
 
 beaker_version = ENV['BEAKER_VERSION']
 beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
-group :system_tests do
-  if beaker_version
-    gem 'beaker', *location_for(beaker_version || '~> 2.26')
-  end
-  if beaker_rspec_version
-    gem 'beaker-rspec', *location_for(beaker_rspec_version)
-  else
-    gem 'beaker-rspec',  :require => false
-  end
-  gem 'serverspec',    :require => false
-  gem 'master_manipulator', '1.1.2',  :require => false
-end
 
 if facterversion = ENV['FACTER_GEM_VERSION']
   gem 'facter', facterversion, :require => false
@@ -46,6 +34,20 @@ if puppetversion = ENV['PUPPET_GEM_VERSION']
   gem 'puppet', puppetversion, :require => false
 else
   gem 'puppet', :require => false
+end
+
+group :system_tests do
+  if beaker_version
+    gem 'beaker', *location_for(beaker_version || '~> 2.26')
+  end
+  if beaker_rspec_version
+    gem 'beaker-rspec', *location_for(beaker_rspec_version)
+  else
+    gem 'beaker-rspec',  :require => false
+  end
+  gem 'beaker-puppet_install_helper', :require => false
+  gem 'serverspec',                   :require => false
+  gem 'master_manipulator', '1.1.2',  :require => false
 end
 
 # vim:ft=ruby

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper_acceptance'
+
+describe 'should install ibm software' do
+  it do
+    pp = <<-EOS
+      class { 'ibm_installation_manager':
+        deploy_source => true,
+        source        => '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip',
+        target        => '/opt/IBM/InstallationManager',
+      }
+    EOS
+    apply_manifest(pp, :catch_failures => true)
+    apply_manifest(pp, :catch_changes => true)
+  end
+end

--- a/spec/acceptance/ibm_pkg_spec.rb
+++ b/spec/acceptance/ibm_pkg_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper_acceptance'
+
+describe 'ibm_pkg should install package' do
+  it do
+    pp = <<-EOS
+      class { 'ibm_installation_manager':
+        deploy_source => true,
+        source        => '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip',
+        target        => '/opt/IBM/InstallationManager',
+      }
+      ibm_pkg { 'Websphere85':
+        ensure        => 'present',
+        package       => 'com.ibm.websphere.NDTRIAL.v85',
+        version       => '8.5.5000.20130514_1044',
+        repository    => "/tmp/ndtrial/repository.config",
+        target        => '/opt/IBM/WebSphere85/AppServer',
+        package_owner => 'root',
+        package_group => 'root',
+      }
+    EOS
+    apply_manifest(pp, :catch_failures => true)
+  end
+end

--- a/spec/acceptance/ibm_pkg_spec.rb
+++ b/spec/acceptance/ibm_pkg_spec.rb
@@ -1,23 +1,116 @@
 require 'spec_helper_acceptance'
 
-describe 'ibm_pkg should install package' do
-  it do
-    pp = <<-EOS
-      class { 'ibm_installation_manager':
-        deploy_source => true,
-        source        => '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip',
-        target        => '/opt/IBM/InstallationManager',
-      }
-      ibm_pkg { 'Websphere85':
-        ensure        => 'present',
-        package       => 'com.ibm.websphere.NDTRIAL.v85',
-        version       => '8.5.5000.20130514_1044',
-        repository    => "/tmp/ndtrial/repository.config",
-        target        => '/opt/IBM/WebSphere85/AppServer',
-        package_owner => 'root',
-        package_group => 'root',
-      }
-    EOS
-    apply_manifest(pp, :catch_failures => true)
+describe 'ibm installation manager ibm_pkg:' do
+  context 'installs package' do
+    it 'should install package' do
+      pp = <<-EOS
+        class { 'ibm_installation_manager':
+          deploy_source => true,
+          source        => '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip',
+          target        => '/opt/IBM/InstallationManager',
+        }
+        ibm_pkg { 'Websphere0':
+          ensure        => 'present',
+          package       => 'com.ibm.websphere.NDTRIAL.v85',
+          version       => '8.5.5000.20130514_1044',
+          repository    => "/tmp/ndtrial/repository.config",
+          target        => '/opt/IBM/WebSphere0/AppServer',
+          package_owner => 'root',
+          package_group => 'root',
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file('/var/ibm/InstallationManager/installed.xml') do
+      it { should be_file }
+      it { should contain '/opt/IBM/WebSphere0/AppServer' }
+    end
+  end
+
+  context 'installs package with manage user' do
+    it 'should install package with user' do
+      pp = <<-EOS
+        class { 'ibm_installation_manager':
+          deploy_source => true,
+          source        => '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip',
+          target        => '/opt/IBM/InstallationManager',
+        }
+        group { 'webadmins':
+          ensure => 'present',
+        }
+        user { 'webadmin':
+          ensure => 'present',
+          gid    => 'webadmins',
+        }
+        ibm_pkg { 'Websphere1':
+          ensure        => 'present',
+          package       => 'com.ibm.websphere.NDTRIAL.v85',
+          version       => '8.5.5000.20130514_1044',
+          repository    => "/tmp/ndtrial/repository.config",
+          target        => '/opt/IBM/WebSphere1/AppServer',
+          package_owner => 'webadmin',
+          package_group => 'webadmins',
+          require       => User['webadmin'],
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file('/var/ibm/InstallationManager/installed.xml') do
+      it { should be_file }
+      it { should contain '/opt/IBM/WebSphere1/AppServer' }
+    end
+
+    describe file('/opt/IBM/WebSphere1/AppServer') do
+      it { should be_directory }
+      it { should be_owned_by 'webadmin' }
+      it { should be_grouped_into 'webadmins' }
+    end
+  end
+
+  context 'installs package without manage user' do
+    it 'should install package with user' do
+      pp = <<-EOS
+        class { 'ibm_installation_manager':
+          deploy_source => true,
+          source        => '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip',
+          target        => '/opt/IBM/InstallationManager',
+        }
+        group { 'webadmins':
+          ensure => 'present',
+        }
+        user { 'webadmin':
+          ensure => 'present',
+          gid    => 'webadmins',
+        }
+        ibm_pkg { 'Websphere2':
+          ensure           => 'present',
+          package          => 'com.ibm.websphere.NDTRIAL.v85',
+          version          => '8.5.5000.20130514_1044',
+          repository       => "/tmp/ndtrial/repository.config",
+          target           => '/opt/IBM/WebSphere2/AppServer',
+          manage_ownership => 'false',
+          package_owner => 'webadmin',
+          package_group => 'webadmins',
+          require       => User['webadmin'],
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file('/var/ibm/InstallationManager/installed.xml') do
+      it { should be_file }
+      it { should contain '/opt/IBM/WebSphere2/AppServer' }
+    end
+
+    describe file('/opt/IBM/WebSphere2/AppServer') do
+      it { should be_directory }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+    end
   end
 end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,9 @@
+HOSTS:
+  centos-70-x64:
+    roles:
+      - master
+    platform: el-7-x86_64
+    box: puppetlabs/centos-7.0-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  type: foss

--- a/spec/acceptance/nodesets/redhat-7-64mda.yml
+++ b/spec/acceptance/nodesets/redhat-7-64mda.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  redhat-7-x86_64:
+    roles:
+    - master
+    - dashboard
+    - database
+    - agent
+    - default
+    platform: el-7-x86_64
+    template: redhat-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,8 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
+
+RSpec.configure do |c|
+  c.module_path = File.join(fixture_path, 'modules')
+  c.manifest_dir =  File.join(fixture_path, 'manifests')
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,38 @@
+require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
+
+run_puppet_install_helper
+
+RSpec.configure do |c|
+  module_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+
+  c.before :suite do
+    #install module
+    puppet_module_install(:source => module_root, :module_name => 'ibm_installation_manager')
+
+    install_pkg_path = "#{module_root}/spec/fixtures/modules/spec_files/files"
+    hosts.each do |host|
+      on host, puppet('module','install','puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module','install','nanliu-staging'), { :acceptable_exit_codes => [0,1] }
+
+      pp = <<-EOS
+        package { 'unzip':
+          ensure => present,
+        }
+      EOS
+      apply_manifest_on(host, pp, :catch_failures => true)
+
+      # scp the ibm installation manager installer
+      scp_to host, "#{install_pkg_path}/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip", "/tmp/"
+      # scp and unzip ibm java7 installer
+      %w(part1 part2 part3).each do |part|
+        scp_to host, "#{install_pkg_path}/was.repo.8550.ndtrial_#{part}.zip", "/tmp/"
+        on host, "/usr/bin/unzip /tmp/was.repo.8550.ndtrial_#{part}.zip -d /tmp/ndtrial/"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently the acceptance tests will only run on ruby 1.9.3 and newer.
The setup for testing requires an SCP of the install files to the test node
which is not ideal, because the files are quite large.

Adds acceptance test for class and ibm_pkg.