### PR TITLE
(FM-4816)Remove absolute path validation on source

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,6 @@ class ibm_installation_manager (
 ) {
 
   validate_bool($deploy_source)
-  validate_absolute_path($source_dir, $target)
   validate_string($options, $user, $group)
   validate_integer($timeout)
 


### PR DESCRIPTION
The validation of absolute path is no longer needed or wanted here
because the source parameter now supports using a URL to download the
package via puppet-archive.