### PR TITLE
Fixes idempotency problem

### DIFF
--- a/lib/puppet/type/ibm_pkg.rb
+++ b/lib/puppet/type/ibm_pkg.rb
@@ -53,35 +53,8 @@ Puppet::Type.newtype(:ibm_pkg) do
 
   ensurable
 
-    def self.title_patterns
-      identity = lambda {|x| x}
-      [
-        [
-        /^(.*):(.*):(.*)$/,
-          [
-            [:target, identity ],
-            [:package, identity ],
-            [:version, identity ]
-          ]
-        ],
-        [
-        /^(.*):(.*)$/,
-          [
-            [:target, identity ],
-            [:package, identity ]
-          ]
-        ],
-        [
-        /^(.*)$/,
-          [
-            [:target, identity ]
-          ]
-        ]
-      ]
-    end
+  newparam(:name, :namevar => true) do
 
-  newparam(:name) do
-    desc "The name of the resource"
   end
 
   newparam(:imcl_path) do
@@ -93,15 +66,11 @@ Puppet::Type.newtype(:ibm_pkg) do
   end
 
   newparam(:target) do
-    isnamevar
-
     desc "The full path to install the specified package to.
     Corresponds to the 'imcl' option '-installationDirectory'"
   end
 
   newparam(:package) do
-    isnamevar
-
     desc "The IBM package name. Example: com.ibm.websphere.IBMJAVA.v71
     This is the first part of the traditional IBM full package name,
     before the first underscore."
@@ -115,15 +84,11 @@ Puppet::Type.newtype(:ibm_pkg) do
   end
 
   newparam(:response) do
-    isnamevar
-
     desc "Full path to an optional response file to use. The user is
     responsible for ensuring this file is present."
   end
 
   newparam(:version) do
-    isnamevar
-
     desc "The version of the package. Example: 7.1.2000.20141116_0823
     This is the second part of the traditional IBM full package name,
     after the first underscore."

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -36,6 +36,7 @@ RSpec.configure do |c|
         archive { '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip':
           source       => "#{INSTALL_FILE_PATH}/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip",
           extract      => false,
+          extract_path => '/tmp',
         }
 
         package { 'unzip':
@@ -52,7 +53,6 @@ RSpec.configure do |c|
           extract      => true,
           extract_path => '/tmp/ndtrial',
           creates      => '/tmp/ndtrial/repository.config',
-          require      => File['/tmp/ndtrial'],
         }
       EOS
       apply_manifest_on(host, pp, :catch_failures => true)


### PR DESCRIPTION
Fixes an idempotency problem when using ibm_pkg to apply a fixpack onto the
same target directory. IBM Installation Manager will overwrite the version
in the installed.xml file with the fixpack version, causing the prefetch
to not pick up the older version. Changing this to retrieve the install
data from installRegistry.xml fixes it.