### PR TITLE
ibm_pkg fixes

### DIFF
--- a/lib/puppet/provider/ibm_pkg/imcl.rb
+++ b/lib/puppet/provider/ibm_pkg/imcl.rb
@@ -126,7 +126,8 @@ Puppet::Type.type(:ibm_pkg).provide(:imcl) do
       end
       begin
         self.debug "Attempting to kill PID #{pids}"
-        output = kill(pids, :combine => true, :failonfail => false)
+        command = "/bin/kill #{pids}"
+        output = Puppet::Util::Execution.execute(command, :combine => true, :failonfail => false)
       rescue Puppet::ExecutionFailure
         err = <<-EOF
         Could not kill #{self.name}, PID #{pids}.

--- a/lib/puppet/provider/ibm_pkg/imcl.rb
+++ b/lib/puppet/provider/ibm_pkg/imcl.rb
@@ -129,10 +129,10 @@ Puppet::Type.type(:ibm_pkg).provide(:imcl) do
         output = kill(pids, :combine => true, :failonfail => false)
       rescue Puppet::ExecutionFailure
         err = <<-EOF
-        Could not kill #{self.name}, PID #{thepid}.
+        Could not kill #{self.name}, PID #{pids}.
         In order to install/upgrade to specified target: #{resource[:target]},
         all related processes need to be stopped.
-        Output of 'kill #{thepid}': #{output}
+        Output of 'kill #{pids}': #{output}
         EOF
         @resource.fail Puppet::Error, err, $!
       end


### PR DESCRIPTION
For some reason it would not stop the processes of WebSphere IHS servers when trying to install a fixpack. 

This change was tested on installing WebSphere AppServers, DMGRs, IHS, and some FixPacks.
