### PR TITLE
[MODULES-4660] Installing with non-root user needs to use 'userinstc' rather than 'installc'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,8 +53,15 @@ class ibm_installation_manager (
     }
   }
 
+  if $user == 'root' {
+    $installc = 'installc'
+  }
+  else {
+    $installc = 'userinstc'
+  }
+
   exec { 'Install IBM Installation Manager':
-    command => "${source_dir}/installc ${_options}",
+    command => "${source_dir}/${installc} ${_options}",
     creates => "${target}/eclipse/tools/imcl",
     cwd     => $source_dir,
     user    => $user,


### PR DESCRIPTION
When user is root, use 'installc' as the installation command. Otherwise (non-root user) use 'userinstc'.