### PR TITLE
Temporarily change working directory to enable non-root installation

### DIFF
--- a/lib/puppet/provider/ibm_pkg/imcl.rb
+++ b/lib/puppet/provider/ibm_pkg/imcl.rb
@@ -81,8 +81,11 @@ Puppet::Type.type(:ibm_pkg).provide(:imcl) do
   end
 
   def imcl(cmd_options)
+    cwd = Dir.pwd
+    Dir.chdir(Dir.home(resource[:user]))
     command = "#{imcl_command_path} #{cmd_options}"
     Puppet::Util::Execution.execute(command, :uid => resource[:user], :combine => true, :failonfail => true)
+    Dir.chdir(cwd)
   end
 
   def getps


### PR DESCRIPTION
When imcl is executed it will fail if the current working directory is not writable by the installation user. This PR will fix this by temporarily changing the working directory to the home directory of the installation user.