### PR TITLE
(MODULES-6288) moves manage group out of groupo installation mode conditional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,6 +87,12 @@ class ibm_installation_manager (
 
     $_options = "-acceptLicense -accessRights nonAdmin -s -log /tmp/IM_install.${timestamp}.log.xml"
 
+    if $manage_group {
+      group { $group:
+        ensure => present,
+      }
+    }
+
     if $manage_user {
       user { $user:
         ensure     => present,
@@ -100,11 +106,6 @@ class ibm_installation_manager (
       $t        = "${user_home}/IBM/InstallationManager"
       $sd       = "${user_home}/IBM/tmp/InstallationManager"
     } elsif $installation_mode == 'group' {
-      if $manage_group {
-        group { $group:
-          ensure => present,
-        }
-      }
       $installc = 'groupinstc'
       $t        = "${user_home}/IBM/InstallationManager_Group"
       $sd       = "${user_home}/IBM/tmp/InstallationManager"


### PR DESCRIPTION
Previously, installation_mode == 'group' was required for manage_group
to actually work. To simplify things, this moves the group management
out of that conditional so that it can be used with any non-root user.
