### PR TITLE
update installed.xml logic, moar changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ sudo: false
 language: ruby
 cache: bundler
 script: "bundle exec rake release_checks"
-#Inserting below due to the following issue: https://github.com/travis-ci/travis-ci/issues/3531#issuecomment-88311203
-before_install:
-  - gem update bundler
 matrix:
   fast_finish: true
   include:

--- a/lib/puppet/provider/ibm_pkg/imcl.rb
+++ b/lib/puppet/provider/ibm_pkg/imcl.rb
@@ -2,7 +2,6 @@
 # Manager.  This could almost be a provider for the package resource, but I'm
 # not sure how.  We need to be able to support multiple installations of the
 # exact same package of the exact same version but in different locations.
-
 #
 # This could also use some work.  I'm obviously lacking in Ruby experience and
 # familiarity with the Puppet development APIs.

--- a/lib/puppet/type/ibm_pkg.rb
+++ b/lib/puppet/type/ibm_pkg.rb
@@ -58,9 +58,9 @@ Puppet::Type.newtype(:ibm_pkg) do
   end
 
   newparam(:imcl_path) do
-    desc "The full path to the IBM Installation Manager location
+    desc "The full path to the imcl executable.
     This is optional. The provider will attempt to locate imcl by
-    parsing /var/ibm/InstallationManager/installed.xml.  If, for
+    parsing /<appDataLocation>/InstallationManager/installed.xml.  If, for
     some reason, it cannot be discovered or if you need to
     provide a specific path, you may do so with this parameter."
   end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,6 +175,13 @@ class ibm_installation_manager (
       group  => $group,
       mode   => '0755',
     }
+
+    file { "${user_home}/var/ibm/InstallationManager":
+      ensure => 'directory',
+      owner  => $user,
+      group  => $group,
+      mode   => '0755',
+    }
   }
 
   $final_cmd = "${_source_dir}/${installc} ${final_opt}"

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -13,6 +13,12 @@ describe 'should install ibm software' do
       apply_manifest(pp, :catch_failures => true)
       apply_manifest(pp, :catch_changes => true)
     end
+
+    describe file("/opt/IBM/InstallationManager/eclipse/tools/imcl") do
+      it { is_expected.to be_file }
+      it { is_expected.to be_owned_by 'root' }
+      it { is_expected.to be_executable }
+    end
   end
   ## IIM module is expected to:
   ## - unzip the source into dir owned by the user
@@ -30,11 +36,23 @@ describe 'should install ibm software' do
           user              => 'webadmin',
           user_home         => '/home/webadmin',
           source            => '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip',
-          target            => '/home/webadmin/IBM/InstallationManager',
         }
       EOS
       apply_manifest(pp, :catch_failures => true)
       apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("/home/webadmin/IBM/InstallationManager/eclipse/tools/imcl") do
+      it { is_expected.to be_file }
+      it { is_expected.to be_owned_by 'webadmin' }
+      it { is_expected.to be_executable }
+    end
+
+    ["/home/webadmin/","/home/webadmin/var"].each do |path|
+      describe file(path) do
+        it { is_expected.to be_directory }
+        it { is_expected.to be_owned_by 'webadmin' }
+      end
     end
   end
 
@@ -45,14 +63,21 @@ describe 'should install ibm software' do
           deploy_source     => true,
           installation_mode => 'group',
           manage_user       => true,
+          manage_group      => true,
           user              => 'webadmin',
+          group             => 'webadmins',
           user_home         => '/home/webadmin',
           source            => '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip',
-          target            => '/home/webadmin/IBM/InstallationManager',
         }
       EOS
       apply_manifest(pp, :catch_failures => true)
       apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe file("/home/webadmin/IBM/InstallationManager_Group/eclipse/tools/imcl") do
+      it { is_expected.to be_file }
+      it { is_expected.to be_grouped_into 'webadmins' }
+      it { is_expected.to be_executable }
     end
   end
 end

--- a/spec/acceptance/ibm_pkg_spec.rb
+++ b/spec/acceptance/ibm_pkg_spec.rb
@@ -35,13 +35,13 @@ describe 'ibm_installation_manager::ibm_pkg' do
       it do
         pp = <<-EOS
         class { 'ibm_installation_manager':
-          deploy_source => true,
-          source        => '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip',
-          manage_user   => true,
-          manage_group  => true,
-          user          => 'webadmin',
-          group         => 'webadmins',
-          user_home     => '/home/webadmin',
+          deploy_source     => true,
+          source            => '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip',
+          manage_user       => true,
+          manage_group      => true,
+          user              => 'webadmin',
+          group             => 'webadmins',
+          user_home         => '/home/webadmin',
           installation_mode => 'nonadministrator',
         }
         ibm_pkg { 'Websphere0':
@@ -50,6 +50,7 @@ describe 'ibm_installation_manager::ibm_pkg' do
           version       => '8.5.5000.20130514_1313',
           repository    => "/tmp/ndtrial/repository.config",
           target        => '/home/webadmin/IBM/WebSphere0/AppServer',
+          user          => 'webadmin',
           package_owner => 'webadmin',
           package_group => 'webadmins',
         }
@@ -71,18 +72,18 @@ describe 'ibm_installation_manager::ibm_pkg' do
       it do
         pp = <<-EOS
         user { 'webadmin':
-          ensure => present,
-          gid    => 'webadmins',
+          ensure     => present,
+          gid        => 'webadmins',
           managehome => true,
-          home => '/home/webadmin',
+          home       => '/home/webadmin',
         }
         class { 'ibm_installation_manager':
-          deploy_source => true,
-          source        => '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip',
-          user          => 'webadmin',
-          user_home     => '/home/webadmin',
-          manage_group  => true,
-          group         => 'webadmins',
+          deploy_source     => true,
+          source            => '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip',
+          user              => 'webadmin',
+          user_home         => '/home/webadmin',
+          manage_group      => true,
+          group             => 'webadmins',
           installation_mode => 'nonadministrator',
         }
         ibm_pkg { 'Websphere0':
@@ -91,8 +92,9 @@ describe 'ibm_installation_manager::ibm_pkg' do
           version       => '8.5.5000.20130514_1313',
           repository    => "/tmp/ndtrial/repository.config",
           target        => '/home/webadmin/IBM/WebSphere0/AppServer',
+          user          => 'webadmin',
           package_owner => 'webadmin',
-          package_group => 'webadmin',
+          package_group => 'webadmins',
         }
         EOS
         apply_manifest(pp, :catch_failures => true)
@@ -173,9 +175,9 @@ describe 'ibm_installation_manager::ibm_pkg' do
           repository       => "/tmp/ndtrial/repository.config",
           target           => '/opt/IBM/WebSphere2/AppServer',
           manage_ownership => 'false',
-          package_owner => 'webadmin',
-          package_group => 'webadmins',
-          require       => User['webadmin'],
+          package_owner    => 'webadmin',
+          package_group    => 'webadmins',
+          require          => User['webadmin'],
         }
       EOS
       apply_manifest(pp, :catch_failures => true)

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -39,7 +39,7 @@ describe 'ibm_installation_manager' do
       }
       it { is_expected.to contain_class('ibm_installation_manager') }
       it { is_expected.to contain_exec('Install IBM Installation Manager').with({
-        :command => /\/home\/webadmin\/IBM\/tmp\/InstallationManager\/groupinstc -acceptLicense -accessRights nonAdmin -s -log.*-installationDirectory \/home\/webadmin\/IBM\/InstallationManager_Group/,
+        :command => /\/home\/webadmin\/IBM\/tmp\/InstallationManager\/groupinstc -acceptLicense -accessRights group -s -log.*-installationDirectory \/home\/webadmin\/IBM\/InstallationManager_Group/,
         :creates => '/home/webadmin/IBM/InstallationManager_Group/eclipse/tools/imcl',
         :user    => 'webadmin',
         :timeout => '900',

--- a/spec/unit/puppet/provider/ibm_pkg/imcl_spec.rb
+++ b/spec/unit/puppet/provider/ibm_pkg/imcl_spec.rb
@@ -1,28 +1,37 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:ibm_pkg).provider(:imcl) do
-  describe '#installed_file' do
-    context 'non-root user' do
-      let (:resource) do
-        Puppet::Type::Ibm_pkg.new({
-                                    name: 'foo',
-                                    user: 'webadmin'
-                                  })
-      end
-      let (:provider) { Puppet::Type.type(:ibm_pkg).provider(:imcl).new(resource) }
-      it 'returns the non-root path' do
-        expect(provider.installed_file).to eq('/home/webadmin/var/ibm/InstallationManager/installed.xml')
+  describe '#installed_xml_paths' do
+    let (:provider) { Puppet::Type.type(:ibm_pkg).provider(:imcl) }
+
+    context 'nonadministrator' do
+      let (:nonroot_path) { '/home/webadmin/var/ibm/InstallationManager/installed.xml' }
+
+      it 'returns the nonadministrator path' do
+        Dir.stubs(:glob).with('/home/*/var/ibm/').returns(nonroot_path)
+        File.stubs(:exist?).with(nonroot_path).returns true
+        File.stubs(:exist?).with('/var/ibm/').returns true
+        Find.stubs(:find).with('/var/ibm/', nonroot_path).yields(nonroot_path).yields('/var/')
+
+        arr = provider.installed_xml_paths
+
+        expect(arr.length).to eq 1
+        expect(arr).to include(nonroot_path)
       end
     end
-    context 'root user' do
-      let (:resource) do
-        Puppet::Type::Ibm_pkg.new({
-                                    name: 'foo'
-                                  })
-      end
-      let (:provider) { Puppet::Type.type(:ibm_pkg).provider(:imcl).new(resource) }
-      it 'returns the root path' do
-        expect(provider.installed_file).to eq('/var/ibm/InstallationManager/installed.xml')
+    context 'administrator' do
+      let (:root_path) { '/var/ibm/InstallationManager/installed.xml' }
+
+      it 'returns the administrator path' do
+        Dir.stubs(:glob).with('/home/*/var/ibm/').returns('/home/webadmin/var/ibm/InstallationManager/installed.xml')
+        File.stubs(:exist?).with('/home/webadmin/var/ibm/InstallationManager/installed.xml').returns true
+        File.stubs(:exist?).with('/var/ibm/').returns true
+        Find.stubs(:find).with('/var/ibm/','/home/webadmin/var/ibm/InstallationManager/installed.xml').yields(root_path).yields('/var/ibm/InstallationManager/blah.xml')
+
+        arr = provider.installed_xml_paths
+
+        expect(arr.length).to eq 1
+        expect(arr).to include(root_path)
       end
     end
   end


### PR DESCRIPTION
closes #61 

Logic around finding both installed.xml and the registry file needed to be more flexible. This does that.
Also,
- updates installation commands for non-admin modes
- adds more acceptance tests
- cleans up some formatting/whitespace
- removes passing target to acceptance tests in class_spec, defaults should handle this
- passes group to the installation exec lest the group installation mode has been selected