### PR TITLE
Adds user_home parameter to imcl provider.

### DIFF
--- a/lib/puppet/provider/ibm_pkg/imcl.rb
+++ b/lib/puppet/provider/ibm_pkg/imcl.rb
@@ -76,7 +76,10 @@ Puppet::Type.type(:ibm_pkg).provide(:imcl) do
   def installed_file
     if resource[:user] == 'root'
       xml_path = '/var/ibm/InstallationManager/installed.xml'
-    else
+    elsif resource[:user] != 'root'
+      if resource[:user_home].nil?
+        raise ArgumentError, 'user_home is not specified for non-admin user %s.' % resource[:user]
+      end
       xml_path = "#{resource[:user_home]}/var/ibm/InstallationManager/installed.xml"
     end
     xml_path

--- a/lib/puppet/provider/ibm_pkg/imcl.rb
+++ b/lib/puppet/provider/ibm_pkg/imcl.rb
@@ -77,7 +77,7 @@ Puppet::Type.type(:ibm_pkg).provide(:imcl) do
     if resource[:user] == 'root'
       xml_path = '/var/ibm/InstallationManager/installed.xml'
     else
-      xml_path = "/home/#{resource[:user]}/var/ibm/InstallationManager/installed.xml"
+      xml_path = "#{resource[:user_home]}/var/ibm/InstallationManager/installed.xml"
     end
     xml_path
   end
@@ -87,7 +87,7 @@ Puppet::Type.type(:ibm_pkg).provide(:imcl) do
   # @param [String] cmd_options - options to be passed to the imcl command
   def imcl(cmd_options)
     cwd = Dir.pwd
-    Dir.chdir(Dir.home(resource[:user]))
+    Dir.chdir(resource[name][:user_home])
     command = "#{imcl_command_path} #{cmd_options}"
     Puppet::Util::Execution.execute(command, :uid => resource[:user], :combine => true, :failonfail => true)
     Dir.chdir(cwd)
@@ -244,7 +244,7 @@ Puppet::Type.type(:ibm_pkg).provide(:imcl) do
       if catalog[name][:user] == 'root'
         registry_file = '/var/ibm/InstallationManager/installRegistry.xml'
       else
-        registry_file = "/home/#{catalog[name][:user]}/var/ibm/InstallationManager/installRegistry.xml"
+        registry_file = "#{catalog[name][:user_home]}/var/ibm/InstallationManager/installRegistry.xml"
       end
     end
     registry = File.open(registry_file)

--- a/lib/puppet/type/ibm_pkg.rb
+++ b/lib/puppet/type/ibm_pkg.rb
@@ -107,6 +107,11 @@ Puppet::Type.newtype(:ibm_pkg) do
     defaultto 'root'
   end
 
+  newparam(:user_home) do
+    desc "The home directory for the installation user."
+    defaultto '/home/webadmin'
+  end
+
   newparam(:manage_ownership, :boolean => true, :parent => Puppet::Parameter::Boolean) do
     desc 'Whether or not to manage the ownership of installed packages. Allows for packages to not be installed as root.'
     defaultto true

--- a/lib/puppet/type/ibm_pkg.rb
+++ b/lib/puppet/type/ibm_pkg.rb
@@ -109,7 +109,6 @@ Puppet::Type.newtype(:ibm_pkg) do
 
   newparam(:user_home) do
     desc "The home directory for the installation user."
-    defaultto '/home/webadmin'
   end
 
   newparam(:manage_ownership, :boolean => true, :parent => Puppet::Parameter::Boolean) do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,9 +102,7 @@ class ibm_installation_manager (
       }
     }
   } else {
-    if $installation_mode != 'nonadministrator' and $installation_mode != 'group' {
-      fail ("Designated installation_mode '${installation_mode}' not supported.")
-    }
+    fail ("Designated installation_mode '${installation_mode}' not supported.")
   }
 
   if $target {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,23 +43,19 @@
 #  Specifies which 'installation mode' you want to use to install the IBM Installation Manager. Values: 'administrator', 'nonadministrator', 'group'. Default: 'administrator'
 #
 class ibm_installation_manager (
-  $deploy_source     = false,
-  $source            = undef,
-  $source_dir        = undef,
-  $target            = undef,
-  $manage_user       = false,
-  $user              = 'root',
-  $user_home         = undef,
-  $manage_group      = false,
-  $group             = 'root',
-  $options           = undef,
-  $timeout           = '900',
-  $installation_mode = 'administrator',
+  Boolean $deploy_source       = false,
+  Boolean $manage_user         = false,
+  String $user                 = 'root',
+  Boolean $manage_group        = false,
+  String $group                = 'root',
+  Integer $timeout             = 900,
+  String $installation_mode    = 'administrator',
+  Optional[String] $source     = undef,
+  Optional[String] $source_dir = undef,
+  Optional[String] $target     = undef,
+  Optional[String] $user_home  = undef,
+  Optional[String] $options    = undef,
 ) {
-
-  validate_bool($deploy_source)
-  validate_string($options, $user, $group)
-  validate_integer($timeout)
 
   if $deploy_source and ! $source {
     fail("${module_name} requires a source parameter to be set.")
@@ -76,39 +72,38 @@ class ibm_installation_manager (
     $t = '/opt/IBM/InstallationManager'
     $sd = '/opt/IBM/tmp/InstallationManager'
     $_options = "-acceptLicense -s -log /tmp/IM_install.${timestamp}.log.xml"
+
+  } elsif $installation_mode == 'nonadministrator' or $installation_mode == 'group' {
+    if !$user or !$user_home or $user == 'root' {
+      fail("You have set installation_mode to ${installation_mode}. This requires a user and user_home to be set and user should not be 'root'.")
+    } else {
+      if $installation_mode == 'nonadministrator' {
+        $installc = 'userinstc'
+        $t        = "${user_home}/IBM/InstallationManager"
+      } elsif $installation_mode == 'group' {
+        $installc = 'groupinstc'
+        $t        = "${user_home}/IBM/InstallationManager_Group"
+      }
+      $sd       = "${user_home}/IBM/tmp/InstallationManager"
+      $_options = "-acceptLicense -accessRights nonAdmin -s -log /tmp/IM_install.${timestamp}.log.xml"
+
+      if $manage_group {
+        group { $group:
+          ensure => present,
+        }
+      }
+
+      if $manage_user {
+        user { $user:
+          ensure     => present,
+          managehome => true,
+          home       => $user_home,
+        }
+      }
+    }
   } else {
     if $installation_mode != 'nonadministrator' and $installation_mode != 'group' {
       fail ("Designated installation_mode '${installation_mode}' not supported.")
-    }
-
-    if !$user or !$user_home or $user == 'root' {
-      fail("You have set installation_mode to ${installation_mode}. This requires a user and user_home to be set and user should not be 'root'.")
-    }
-
-    $_options = "-acceptLicense -accessRights nonAdmin -s -log /tmp/IM_install.${timestamp}.log.xml"
-
-    if $manage_group {
-      group { $group:
-        ensure => present,
-      }
-    }
-
-    if $manage_user {
-      user { $user:
-        ensure     => present,
-        managehome => true,
-        home       => $user_home,
-      }
-    }
-
-    if $installation_mode == 'nonadministrator' {
-      $installc = 'userinstc'
-      $t        = "${user_home}/IBM/InstallationManager"
-      $sd       = "${user_home}/IBM/tmp/InstallationManager"
-    } elsif $installation_mode == 'group' {
-      $installc = 'groupinstc'
-      $t        = "${user_home}/IBM/InstallationManager_Group"
-      $sd       = "${user_home}/IBM/tmp/InstallationManager"
     }
   }
 
@@ -129,7 +124,7 @@ class ibm_installation_manager (
       creates => $_source_dir,
       user    => $user,
       group   => $group,
-      path    => '/bin:/usr/bin:/sbin:/usr/sbin'
+      path    => '/bin:/usr/bin:/sbin:/usr/sbin',
     }
 
     file { $_source_dir:

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,7 +8,7 @@ describe 'ibm_installation_manager' do
         :command => /\/opt\/IBM\/tmp\/InstallationManager\/installc -acceptLicense -s -log.*-installationDirectory \/opt\/IBM\/InstallationManager/,
         :creates => '/opt/IBM/InstallationManager/eclipse/tools/imcl',
         :user    => 'root',
-        :timeout => '900',
+        :timeout => 900,
       })}
     end
 
@@ -17,16 +17,15 @@ describe 'ibm_installation_manager' do
         {
           installation_mode: 'nonadministrator',
           user: 'webadmin',
-          user_home: '/home/webadmin'
+          user_home: '/home/webadmin',
         }
       }
       it { is_expected.to contain_class('ibm_installation_manager') }
-      it { is_expected.to contain_exec('Install IBM Installation Manager').with({
+      it { is_expected.to contain_exec('Install IBM Installation Manager').with(
         :command => /\/home\/webadmin\/IBM\/tmp\/InstallationManager\/userinstc -acceptLicense -accessRights nonAdmin -s -log.*-installationDirectory \/home\/webadmin\/IBM\/InstallationManager/,
         :creates => '/home/webadmin/IBM/InstallationManager/eclipse/tools/imcl',
-        :user    => 'webadmin',
-        :timeout => '900',
-      })}
+        :timeout => 900,
+      )}
     end
 
     context 'group' do
@@ -34,7 +33,7 @@ describe 'ibm_installation_manager' do
         {
           installation_mode: 'group',
           user: 'webadmin',
-          user_home: '/home/webadmin'
+          user_home: '/home/webadmin',
         }
       }
       it { is_expected.to contain_class('ibm_installation_manager') }
@@ -42,7 +41,7 @@ describe 'ibm_installation_manager' do
         :command => /\/home\/webadmin\/IBM\/tmp\/InstallationManager\/groupinstc -acceptLicense -accessRights nonAdmin -s -log.*-installationDirectory \/home\/webadmin\/IBM\/InstallationManager_Group/,
         :creates => '/home/webadmin/IBM/InstallationManager_Group/eclipse/tools/imcl',
         :user    => 'webadmin',
-        :timeout => '900',
+        :timeout => 900,
       })}
     end
   end
@@ -52,14 +51,14 @@ describe 'ibm_installation_manager' do
       {
         :target     => '/opt/myorg/InstallationManager',
         :source_dir => '/opt/myorg/tmp/InstallationManager',
-        :timeout    => '1200',
+        :timeout    => 1200,
       }
     }
     it { is_expected.to contain_exec('Install IBM Installation Manager').with({
       :command => /\/opt\/myorg\/tmp\/InstallationManager\/installc -acceptLicense -s -log.*-installationDirectory \/opt\/myorg\/InstallationManager/,
       :creates => '/opt/myorg/InstallationManager/eclipse/tools/imcl',
       :user    => 'root',
-      :timeout => '1200',
+      :timeout => 1200,
     })}
   end
 

--- a/spec/unit/puppet/provider/ibm_pkg/imcl_spec.rb
+++ b/spec/unit/puppet/provider/ibm_pkg/imcl_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Puppet::Type.type(:ibm_pkg).provider(:imcl) do
   describe '#installed_file' do
-    context 'non-root user' do
+    context 'non-root user with user and user_home provided' do
       let(:resource) do
         Puppet::Type::Ibm_pkg.new(
           name: 'foo',
@@ -14,6 +14,19 @@ describe Puppet::Type.type(:ibm_pkg).provider(:imcl) do
 
       it 'returns the non-root path' do
         expect(provider.installed_file).to eq('/home/webadmin/var/ibm/InstallationManager/installed.xml')
+      end
+    end
+    context 'non-root user with only user parameter provided' do
+      let(:resource) do
+        Puppet::Type::Ibm_pkg.new(
+          name: 'foo',
+          user: 'webadmin',
+        )
+      end
+      let(:provider) { Puppet::Type.type(:ibm_pkg).provider(:imcl).new(resource) }
+
+      it 'should provide the wrong directory if user_home is not passed.' do
+        expect(provider.installed_file).not_to eq('/home/webadmin/var/ibm/InstallationManager/installed.xml')
       end
     end
     context 'root user' do

--- a/spec/unit/puppet/provider/ibm_pkg/imcl_spec.rb
+++ b/spec/unit/puppet/provider/ibm_pkg/imcl_spec.rb
@@ -25,8 +25,8 @@ describe Puppet::Type.type(:ibm_pkg).provider(:imcl) do
       end
       let(:provider) { Puppet::Type.type(:ibm_pkg).provider(:imcl).new(resource) }
 
-      it 'should provide the wrong directory if user_home is not passed.' do
-        expect(provider.installed_file).not_to eq('/home/webadmin/var/ibm/InstallationManager/installed.xml')
+      it 'will error out if user_home is not passed.' do
+        expect { provider.installed_file }.to raise_error(ArgumentError, %r{user_home is not specified})
       end
     end
     context 'root user' do

--- a/spec/unit/puppet/provider/ibm_pkg/imcl_spec.rb
+++ b/spec/unit/puppet/provider/ibm_pkg/imcl_spec.rb
@@ -3,24 +3,23 @@ require 'spec_helper'
 describe Puppet::Type.type(:ibm_pkg).provider(:imcl) do
   describe '#installed_file' do
     context 'non-root user' do
-      let (:resource) do
-        Puppet::Type::Ibm_pkg.new({
-                                    name: 'foo',
-                                    user: 'webadmin'
-                                  })
+      let(:resource) do
+        Puppet::Type::Ibm_pkg.new(
+          name: 'foo',
+          user: 'webadmin',
+          user_home: '/home/webadmin',
+        )
       end
-      let (:provider) { Puppet::Type.type(:ibm_pkg).provider(:imcl).new(resource) }
+      let(:provider) { Puppet::Type.type(:ibm_pkg).provider(:imcl).new(resource) }
+
       it 'returns the non-root path' do
         expect(provider.installed_file).to eq('/home/webadmin/var/ibm/InstallationManager/installed.xml')
       end
     end
     context 'root user' do
-      let (:resource) do
-        Puppet::Type::Ibm_pkg.new({
-                                    name: 'foo'
-                                  })
-      end
-      let (:provider) { Puppet::Type.type(:ibm_pkg).provider(:imcl).new(resource) }
+      let(:resource) { Puppet::Type::Ibm_pkg.new(name: 'foo') }
+      let(:provider) { Puppet::Type.type(:ibm_pkg).provider(:imcl).new(resource) }
+
       it 'returns the root path' do
         expect(provider.installed_file).to eq('/var/ibm/InstallationManager/installed.xml')
       end


### PR DESCRIPTION
We have had failing websphere installs due to the installation user having a non-standard home directory location (i.e., /export/home vs. /home). This adds the user_home parameter to the installation manager while still maintaining compatibility with the defaults.