### PR TITLE
(MODULES-4738) add support for IIM 1.8.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Specifies the user to run the `imcl` command as. This user must have the necessa
 
 ## Limitations
 
-Tested with RHEL 5, 6, and 7 x86_64 and IBM Installation Manager 1.8.3 and 1.6.x
+Tested with RHEL 5, 6, and 7 x86_64 and IBM Installation Manager 1.8.7 and 1.6.x
 
 ## Known Issues
 

--- a/lib/puppet/provider/ibm_pkg/imcl.rb
+++ b/lib/puppet/provider/ibm_pkg/imcl.rb
@@ -187,9 +187,11 @@ Puppet::Type.type(:ibm_pkg).provide(:imcl) do
       cmd_options = "input #{resource[:response]}"
     elsif resource[:user] == 'root'
       cmd_options =  "install #{resource[:package]}_#{resource[:version]}"
+      cmd_options << " #{resource[:jdk_package_name]}_#{resource[:jdk_package_version]}" unless resource[:jdk_package_name].nil?
       cmd_options << " -repositories #{resource[:repository]} -installationDirectory #{resource[:target]}"
     else
       cmd_options =  "install #{resource[:package]}_#{resource[:version]}"
+      cmd_options << " #{resource[:jdk_package_name]}_#{resource[:jdk_package_version]}" unless resource[:jdk_package_name].nil?
       cmd_options << " -repositories #{resource[:repository]} -installationDirectory #{resource[:target]} -accessRights nonAdmin"
     end
     cmd_options << ' -acceptLicense'

--- a/lib/puppet/type/ibm_pkg.rb
+++ b/lib/puppet/type/ibm_pkg.rb
@@ -15,6 +15,8 @@ require 'pathname'
 require 'puppet/parameter/boolean'
 
 Puppet::Type.newtype(:ibm_pkg) do
+  desc "Custom type for installing an IBM package."
+
   autorequire(:file) do
     self[:target]
   end
@@ -53,6 +55,17 @@ Puppet::Type.newtype(:ibm_pkg) do
   ensurable
 
   newparam(:name, namevar: true) do
+  end
+
+  newparam(:jdk_package_name) do
+    desc "If a JDK must be installed separately (as in the case of Websphere Application Server 9), specify
+    the package_name here (everything before the underscore in the IBM package name)."
+  end
+
+  newparam(:jdk_package_version) do
+    desc "If a JDK must be installed separately (as in the case of Websphere Application Server 9), specify
+    the version here. Like 'version', this parameter refers to the number after the underscore in the IBM
+    package name."
   end
 
   newparam(:imcl_path) do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,6 @@
 #
 # @example Installing Installation Manager to the default location of '/opt/IBM/InstallationManager'. In this example, we've downloaded and  extracted the Installation Manager packages (installer) to '/vagrant/ibm/IM'
 #  class { 'ibm_installation_manager':
-
 #    source_dir => '/vagrant/ibm/IM',
 #  }
 #

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,83 +1,89 @@
 require 'spec_helper_acceptance'
 
-describe 'should install ibm software' do
-  context 'default/administrator mode' do
-    it do
-      pp = <<-EOS
-        class { 'ibm_installation_manager':
-          deploy_source => true,
-          source        => '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip',
-          target        => '/opt/IBM/InstallationManager',
-        }
-      EOS
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+IIM_VERSIONS.each do |version|
+  describe 'should install ibm software' do
+    after :each do
+      FileUtils.rm_rf('/opt/IBM/InstallationManager')
     end
 
-    describe file('/opt/IBM/InstallationManager/eclipse/tools/imcl') do
-      it { is_expected.to be_file }
-      it { is_expected.to be_owned_by 'root' }
-      it { is_expected.to be_executable }
-    end
-  end
-  ## IIM module is expected to:
-  ## - unzip the source into dir owned by the user
-  ## - execute imcl command as the user
-  ## - install IIM as user into the user's home
-  ## - install IIM as user into writable dirs owned by the user
+    context 'default/administrator mode' do
+      it do
+        pp = <<-EOS
+          class { 'ibm_installation_manager':
+            deploy_source => true,
+            source        => '/tmp/agent.installer.linux.gtk.x86_64_#{version}.zip',
+            target        => '/opt/IBM/InstallationManager',
+          }
+        EOS
+        apply_manifest(pp, catch_failures: true)
+        apply_manifest(pp, catch_changes: true)
+      end
 
-  context 'nonadministrator mode' do
-    it do
-      pp = <<-EOS
-        class { 'ibm_installation_manager':
-          deploy_source     => true,
-          installation_mode => 'nonadministrator',
-          manage_user       => true,
-          user              => 'webadmin',
-          user_home         => '/home/webadmin',
-          source            => '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip',
-        }
-      EOS
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
-    end
-
-    describe file('/home/webadmin/IBM/InstallationManager/eclipse/tools/imcl') do
-      it { is_expected.to be_file }
-      it { is_expected.to be_owned_by 'webadmin' }
-      it { is_expected.to be_executable }
-    end
-
-    ['/home/webadmin/', '/home/webadmin/var'].each do |path|
-      describe file(path) do
-        it { is_expected.to be_directory }
-        it { is_expected.to be_owned_by 'webadmin' }
+      describe file('/opt/IBM/InstallationManager/eclipse/tools/imcl') do
+        it { is_expected.to be_file }
+        it { is_expected.to be_owned_by 'root' }
+        it { is_expected.to be_executable }
       end
     end
-  end
+    ## IIM module is expected to:
+    ## - unzip the source into dir owned by the user
+    ## - execute imcl command as the user
+    ## - install IIM as user into the user's home
+    ## - install IIM as user into writable dirs owned by the user
 
-  context 'group mode' do
-    it do
-      pp = <<-EOS
-        class { 'ibm_installation_manager':
-          deploy_source     => true,
-          installation_mode => 'group',
-          manage_user       => true,
-          manage_group      => true,
-          user              => 'webadmin',
-          group             => 'webadmins',
-          user_home         => '/home/webadmin',
-          source            => '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip',
-        }
-      EOS
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+    context 'nonadministrator mode' do
+      it do
+        pp = <<-EOS
+          class { 'ibm_installation_manager':
+            deploy_source     => true,
+            installation_mode => 'nonadministrator',
+            manage_user       => true,
+            user              => 'webadmin',
+            user_home         => '/home/webadmin',
+            source            => '/tmp/agent.installer.linux.gtk.x86_64_#{version}.zip',
+          }
+        EOS
+        apply_manifest(pp, catch_failures: true)
+        apply_manifest(pp, catch_changes: true)
+      end
+
+      describe file('/home/webadmin/IBM/InstallationManager/eclipse/tools/imcl') do
+        it { is_expected.to be_file }
+        it { is_expected.to be_owned_by 'webadmin' }
+        it { is_expected.to be_executable }
+      end
+
+      ['/home/webadmin/', '/home/webadmin/var'].each do |path|
+        describe file(path) do
+          it { is_expected.to be_directory }
+          it { is_expected.to be_owned_by 'webadmin' }
+        end
+      end
     end
 
-    describe file('/home/webadmin/IBM/InstallationManager_Group/eclipse/tools/imcl') do
-      it { is_expected.to be_file }
-      it { is_expected.to be_grouped_into 'webadmins' }
-      it { is_expected.to be_executable }
+    context 'group mode' do
+      it do
+        pp = <<-EOS
+          class { 'ibm_installation_manager':
+            deploy_source     => true,
+            installation_mode => 'group',
+            manage_user       => true,
+            manage_group      => true,
+            user              => 'webadmin',
+            group             => 'webadmins',
+            user_home         => '/home/webadmin',
+            source            => '/tmp/agent.installer.linux.gtk.x86_64_#{version}.zip',
+          }
+        EOS
+        apply_manifest(pp, catch_failures: true)
+        apply_manifest(pp, catch_changes: true)
+      end
+
+      describe file('/home/webadmin/IBM/InstallationManager_Group/eclipse/tools/imcl') do
+        it { is_expected.to be_file }
+        it { is_expected.to be_grouped_into 'webadmins' }
+        it { is_expected.to be_executable }
+      end
     end
   end
 end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,89 +1,83 @@
 require 'spec_helper_acceptance'
 
-IIM_VERSIONS.each do |version|
-  describe 'should install ibm software' do
-    after :each do
-      FileUtils.rm_rf('/opt/IBM/InstallationManager')
+describe 'should install ibm software' do
+  context 'default/administrator mode' do
+    it do
+      pp = <<-EOS
+        class { 'ibm_installation_manager':
+          deploy_source => true,
+          source        => '/tmp/agent.installer.linux.gtk.x86_64_1.8.7000.20170706_2137.zip',
+          target        => '/opt/IBM/InstallationManager',
+        }
+      EOS
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
     end
 
-    context 'default/administrator mode' do
-      it do
-        pp = <<-EOS
-          class { 'ibm_installation_manager':
-            deploy_source => true,
-            source        => '/tmp/agent.installer.linux.gtk.x86_64_#{version}.zip',
-            target        => '/opt/IBM/InstallationManager',
-          }
-        EOS
-        apply_manifest(pp, catch_failures: true)
-        apply_manifest(pp, catch_changes: true)
-      end
-
-      describe file('/opt/IBM/InstallationManager/eclipse/tools/imcl') do
-        it { is_expected.to be_file }
-        it { is_expected.to be_owned_by 'root' }
-        it { is_expected.to be_executable }
-      end
+    describe file('/opt/IBM/InstallationManager/eclipse/tools/imcl') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_owned_by 'root' }
+      it { is_expected.to be_executable }
     end
-    ## IIM module is expected to:
-    ## - unzip the source into dir owned by the user
-    ## - execute imcl command as the user
-    ## - install IIM as user into the user's home
-    ## - install IIM as user into writable dirs owned by the user
+  end
+  ## IIM module is expected to:
+  ## - unzip the source into dir owned by the user
+  ## - execute imcl command as the user
+  ## - install IIM as user into the user's home
+  ## - install IIM as user into writable dirs owned by the user
 
-    context 'nonadministrator mode' do
-      it do
-        pp = <<-EOS
-          class { 'ibm_installation_manager':
-            deploy_source     => true,
-            installation_mode => 'nonadministrator',
-            manage_user       => true,
-            user              => 'webadmin',
-            user_home         => '/home/webadmin',
-            source            => '/tmp/agent.installer.linux.gtk.x86_64_#{version}.zip',
-          }
-        EOS
-        apply_manifest(pp, catch_failures: true)
-        apply_manifest(pp, catch_changes: true)
-      end
+  context 'nonadministrator mode' do
+    it do
+      pp = <<-EOS
+        class { 'ibm_installation_manager':
+          deploy_source     => true,
+          installation_mode => 'nonadministrator',
+          manage_user       => true,
+          user              => 'webadmin',
+          user_home         => '/home/webadmin',
+          source            => '/tmp/agent.installer.linux.gtk.x86_64_1.8.7000.20170706_2137.zip',
+        }
+      EOS
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
 
-      describe file('/home/webadmin/IBM/InstallationManager/eclipse/tools/imcl') do
-        it { is_expected.to be_file }
+    describe file('/home/webadmin/IBM/InstallationManager/eclipse/tools/imcl') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_owned_by 'webadmin' }
+      it { is_expected.to be_executable }
+    end
+
+    ['/home/webadmin/', '/home/webadmin/var'].each do |path|
+      describe file(path) do
+        it { is_expected.to be_directory }
         it { is_expected.to be_owned_by 'webadmin' }
-        it { is_expected.to be_executable }
-      end
-
-      ['/home/webadmin/', '/home/webadmin/var'].each do |path|
-        describe file(path) do
-          it { is_expected.to be_directory }
-          it { is_expected.to be_owned_by 'webadmin' }
-        end
       end
     end
+  end
 
-    context 'group mode' do
-      it do
-        pp = <<-EOS
-          class { 'ibm_installation_manager':
-            deploy_source     => true,
-            installation_mode => 'group',
-            manage_user       => true,
-            manage_group      => true,
-            user              => 'webadmin',
-            group             => 'webadmins',
-            user_home         => '/home/webadmin',
-            source            => '/tmp/agent.installer.linux.gtk.x86_64_#{version}.zip',
-          }
-        EOS
-        apply_manifest(pp, catch_failures: true)
-        apply_manifest(pp, catch_changes: true)
-      end
+  context 'group mode' do
+    it do
+      pp = <<-EOS
+        class { 'ibm_installation_manager':
+          deploy_source     => true,
+          installation_mode => 'group',
+          manage_user       => true,
+          manage_group      => true,
+          user              => 'webadmin',
+          group             => 'webadmins',
+          user_home         => '/home/webadmin',
+          source            => '/tmp/agent.installer.linux.gtk.x86_64_1.8.7000.20170706_2137.zip',
+        }
+      EOS
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
 
-      describe file('/home/webadmin/IBM/InstallationManager_Group/eclipse/tools/imcl') do
-        it { is_expected.to be_file }
-        it { is_expected.to be_grouped_into 'webadmins' }
-        it { is_expected.to be_executable }
-      end
+    describe file('/home/webadmin/IBM/InstallationManager_Group/eclipse/tools/imcl') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_grouped_into 'webadmins' }
+      it { is_expected.to be_executable }
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -21,6 +21,7 @@ RSpec.configure do |c|
   #
   INSTALL_FILE_PATH = ENV['IBM_INSTALL_SOURCE'] || 'http://int-resources.ops.puppetlabs.net/modules/ibm_installation_manager/'
 
+  IIM_VERSIONS = ['1.6.2000.20130301_2248','1.8.7000.20171706_2137']
   # Configure all nodes in nodeset
   c.before :suite do
     # install module
@@ -32,13 +33,18 @@ RSpec.configure do |c|
       on host, puppet('module', 'install', 'puppet-archive'), acceptable_exit_codes: [0, 1]
 
       # Retrieve the install files for tests.
-      pp = <<-EOS
-        archive { '/tmp/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip':
-          source       => "#{INSTALL_FILE_PATH}/agent.installer.linux.gtk.x86_64_1.6.2000.20130301_2248.zip",
-          extract      => false,
-          extract_path => '/tmp',
-        }
+     IIM_VERSIONS.each do |version|
+        pp = <<-EOS
+          archive { '/tmp/agent.installer.linux.gtk.x86_64_#{version}.zip':
+            source       => "#{INSTALL_FILE_PATH}/agent.installer.linux.gtk.x86_64_#{version}.zip",
+            extract      => false,
+            extract_path => '/tmp',
+          }
+          EOS
+        apply_manifest_on(host, pp, catch_failures: true)
+      end
 
+      pp = <<-EOS
         package { 'unzip':
           ensure => present,
           before => Archive['/tmp/ndtrial/was.repo.8550.liberty.ndtrial.zip'],

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -19,9 +19,8 @@ RSpec.configure do |c|
   # To specify a url:
   #     "http://path.of/zip_files"
   #
-  INSTALL_FILE_PATH = ENV['IBM_INSTALL_SOURCE'] || 'http://int-resources.ops.puppetlabs.net/modules/ibm_installation_manager/'
+  INSTALL_FILE_PATH = ENV['IBM_INSTALL_SOURCE'] || 'http://int-resources.ops.puppetlabs.net/modules/ibm_installation_manager'
 
-  IIM_VERSIONS = ['1.6.2000.20130301_2248','1.8.7000.20171706_2137']
   # Configure all nodes in nodeset
   c.before :suite do
     # install module
@@ -33,18 +32,13 @@ RSpec.configure do |c|
       on host, puppet('module', 'install', 'puppet-archive'), acceptable_exit_codes: [0, 1]
 
       # Retrieve the install files for tests.
-     IIM_VERSIONS.each do |version|
-        pp = <<-EOS
-          archive { '/tmp/agent.installer.linux.gtk.x86_64_#{version}.zip':
-            source       => "#{INSTALL_FILE_PATH}/agent.installer.linux.gtk.x86_64_#{version}.zip",
-            extract      => false,
-            extract_path => '/tmp',
-          }
-          EOS
-        apply_manifest_on(host, pp, catch_failures: true)
-      end
-
       pp = <<-EOS
+        archive { '/tmp/agent.installer.linux.gtk.x86_64_1.8.7000.20170706_2137.zip':
+          source       => "#{INSTALL_FILE_PATH}/agent.installer.linux.gtk.x86_64_1.8.7000.20170706_2137.zip",
+          extract      => false,
+          extract_path => '/tmp',
+        }
+
         package { 'unzip':
           ensure => present,
           before => Archive['/tmp/ndtrial/was.repo.8550.liberty.ndtrial.zip'],


### PR DESCRIPTION
Currently, this module is only being tested with version 1.6.2 of IIM (although it also claims support for 1.8.3. This adds tests with version 1.8.7 and updates the README to reflect the actually supported versions.

Currently, when using imcl install, you can only specify one package name. For installing WebSphere 9.x, you must also pass the jdk package name and jdk_package_version in the same line. This inserts the name of the jdk package and version into the command where it needs to be alongside the other package name if it is not nil.