### PR TITLE
MODULES-7308 Services must be stopped when uninstl

### DIFF
--- a/lib/puppet/provider/ibm_pkg/imcl.rb
+++ b/lib/puppet/provider/ibm_pkg/imcl.rb
@@ -231,6 +231,7 @@ Puppet::Type.type(:ibm_pkg).provide(:imcl) do
   end
 
   def destroy
+    stopprocs
     cmd_options = "uninstall #{resource[:package]}_#{resource[:version]} -s -installationDirectory #{resource[:target]}"
     imcl(cmd_options)
   end


### PR DESCRIPTION
Uninstalling a package was not making sure the server was stopped before attempting the uninstall. 