### PR TITLE
(maint) - Update to add support entry for oracle 5

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -37,6 +37,7 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
+        "5",
         "6",
         "7"
       ]


### PR DESCRIPTION
Currently we support Oracle 5 however our documentation did not state this. Updating to list support for Oracle 5.