### PR TITLE
Replace generate timestamp function with function that will work on WIN.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,7 +74,7 @@ class ibm_installation_manager (
     fail("${module_name} requires a source parameter to be set.")
   }
 
-  $timestamp = chomp(generate('/bin/date', '+%Y%d%m_%H%M%S'))
+  $timestamp = chomp(datetime::date('+%Y%d%m_%H%M%S'))
 
   if $installation_mode == 'administrator' {
     if $user != 'root' {

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,10 @@
   "issues_url": "https://github.com/puppetlabs/puppetlabs-ibm_installation_manager/issues",
   "dependencies": [
     {
+      "name": "fervid-datetime",
+      "version_requirement": ">= 1.0.0 < 2.0.0"
+    },
+    {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.6.0 < 7.0.0"
     },


### PR DESCRIPTION
Needed for onceover testing on WIN.