### PR TITLE
Timestamp retrieval function now Puppet native

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,7 +74,7 @@ class ibm_installation_manager (
     fail("${module_name} requires a source parameter to be set.")
   }
 
-  $timestamp = chomp(generate('/bin/date', '+%Y%d%m_%H%M%S'))
+  $timestamp = strftime('+%Y%d%m_%H%M%S')
 
   if $installation_mode == 'administrator' {
     if $user != 'root' {


### PR DESCRIPTION
We were unable to do onceover testing using this module. We developed one WIN OS.

The original method of timestamp retrieval used the generate function. This would only work on Linux.

We are now using a Puppet native function that is cross platform. Onceover will work.