### PR TITLE
Make installation of unzip optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,9 @@
 # @param installation_mode
 #   Specifies which 'installation mode' you want to use to install the IBM Installation Manager. Values: 'administrator', 'nonadministrator', 'group'.
 #
+# @param install_unzip_package
+#   Default: true. Installs the unzip package.
+
 class ibm_installation_manager (
   $deploy_source     = false,
   $source            = undef,
@@ -64,6 +67,7 @@ class ibm_installation_manager (
   $options           = undef,
   $timeout           = '900',
   $installation_mode = 'administrator',
+  $install_unzip_package = true,
 ) {
 
   validate_bool($deploy_source)
@@ -158,10 +162,11 @@ class ibm_installation_manager (
       owner  => $user,
       group  => $group,
     }
-
-    package { 'unzip':
-      ensure => present,
-      before => Archive["${_source_dir}/ibm-agent_installer.zip"],
+    if $install_unzip_package {
+      package { 'unzip':
+        ensure => present,
+        before => Archive["${_source_dir}/ibm-agent_installer.zip"],
+      }
     }
 
     archive { "${_source_dir}/ibm-agent_installer.zip":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,18 +55,18 @@
 #   Default: true. Installs the unzip package.
 
 class ibm_installation_manager (
-  $deploy_source     = false,
-  $source            = undef,
-  $source_dir        = undef,
-  $target            = undef,
-  $manage_user       = false,
-  $user              = 'root',
-  $user_home         = undef,
-  $manage_group      = false,
-  $group             = 'root',
-  $options           = undef,
-  $timeout           = '900',
-  $installation_mode = 'administrator',
+  $deploy_source         = false,
+  $source                = undef,
+  $source_dir            = undef,
+  $target                = undef,
+  $manage_user           = false,
+  $user                  = 'root',
+  $user_home             = undef,
+  $manage_group          = false,
+  $group                 = 'root',
+  $options               = undef,
+  $timeout               = '900',
+  $installation_mode     = 'administrator',
   $install_unzip_package = true,
 ) {
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -65,6 +65,34 @@ describe 'ibm_installation_manager' do
     }
   end
 
+  context 'install_unzip_package = true' do
+    let(:params) do
+      {
+        install_unzip_package: true,
+        deploy_source: true,
+        source: '/opt/IBM/tmp/InstallationManager/ibm-agent_installer.zip',
+      }
+    end
+
+    describe 'install_unzip_package set to true' do
+      it { is_expected.to contain_package('unzip').with(ensure: 'present') }
+    end
+  end
+
+  context 'install_unzip_package = false' do
+    let(:params) do
+      {
+        install_unzip_package: false,
+        deploy_source: true,
+        source: '/opt/IBM/tmp/InstallationManager/ibm-agent_installer.zip',
+      }
+    end
+
+    describe 'install_unzip_package set to false' do
+      it { is_expected.not_to contain_package('unzip') }
+    end
+  end
+
   context 'deploy source = true' do
     let(:params) do
       {


### PR DESCRIPTION
Make the installation of the unzip package optional. Many systems install the unzip package separately. By hardcoding it, duplicate declaration errors arise in systems where this is true.