### PR TITLE
pdksync - Use abs instead of vmpooler to provision test resources

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -1,8 +1,8 @@
 ---
 default:
 pr_checks:
-  provisioner: vmpooler
+  provisioner: abs
   images: ['redhat-7-x86_64', 'centos-7-x86_64', 'oracle-7-x86_64', 'scientific-7-x86_64', 'debian-9-x86_64', 'ubuntu-1604-x86_64']
 release_checks:
-  provisioner: vmpooler
+  provisioner: abs
   images: ['redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-6-x86_64', 'centos-7-x86_64',  'centos-8-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64',  'debian-10-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64']


### PR DESCRIPTION
Use abs instead of vmpooler to provision test resources
pdk version: `1.17.0` 
