### PR TITLE
pdksync - (maint) Remove RHEL 5 family support; Clean up OS naming in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
         "8"
@@ -30,7 +29,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
         "8"
@@ -39,7 +37,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -54,7 +51,9 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9",
+        "10"
       ]
     },
     {
@@ -62,7 +61,8 @@
       "operatingsystemrelease": [
         "14.04",
         "16.04",
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     },
     {


### PR DESCRIPTION
(maint) Remove RHEL 5 family support; Clean up OS naming in metadata.json
pdk version: `1.18.1` 
